### PR TITLE
check data type if overwriting multi-dimensional arrays

### DIFF
--- a/packages/core/lib/mocks/resolve.js
+++ b/packages/core/lib/mocks/resolve.js
@@ -474,7 +474,11 @@ function overwriteRenderKey(app, data) {
   let o;
 
   if (data) {
-    o = { ...data };
+    if (Array.isArray(data)) {
+      o = [ ...data ];
+    } else {
+      o = { ...data };
+    }
     const entries = Object.entries(o);
     for (const [key, val] of entries) {
       if (key === "$render") {


### PR DESCRIPTION
`overwriteRenderKey` will transform data with a 3 dimensional array into an object, therefore breaking validation:

```
specs:
  - - lorem
     - ipsum
  - - hello
     - world
```
===>
expected:
```
{
  "specs": [
    ["lorem", "ipsum"],
    ["hello", "world"]
  ]
}
```
Actual output:
```
{
  "specs": [{
      "0": "lorem",
      "1": "ipsum"
    },
    {
      "0": "hello",
      "1": "world"
    }
  ]
}
```