### PR TITLE
keep false and zero values

### DIFF
--- a/packages/twig-drupal/index.js
+++ b/packages/twig-drupal/index.js
@@ -222,7 +222,7 @@ module.exports = {
 
     const o = {};
     Object.entries(data).forEach(async ([attr, entries]) => {
-      if (entries) {
+      if (!(entries === null || entries === undefined)) {
         if (entries["$drupal"]) {
           o[attr] = new DrupalAttribute(Object.entries(entries));
         } else if (


### PR DESCRIPTION
issue: mock validation fails if a required value is `0` or `false`