### PR TITLE
fix(core): respect opts when merging ref data

### DIFF
--- a/packages/core/lib/mocks/resolve.js
+++ b/packages/core/lib/mocks/resolve.js
@@ -460,7 +460,7 @@ async function getRootOrVariantDataOfReference(app, ref) {
       }
     }
 
-    return deepMerge(helpers.cloneDeep(rootJson), variantJson);
+    return mergeRootDataWithVariationData(helpers.cloneDeep(rootJson), variantJson);
   }
   log(
     "warn",


### PR DESCRIPTION
When using tpls the root data always gets merged with variant data no matter what `$opts` says. This MR fixes this issue