### PR TITLE
fix: Allow Ctrl+Click on variants for opening in new tab

### DIFF
--- a/packages/core/assets/js/_main.js
+++ b/packages/core/assets/js/_main.js
@@ -261,7 +261,7 @@ class Main {
   addLinksClickListener() {
     this.elements.links.forEach((link) => {
       link.addEventListener("click", (e) => {
-        if (!e.metaKey) {
+        if (!e.metaKey && !e.ctrlKey) {
           e.preventDefault();
           this.onLinkClick(e.target);
         }


### PR DESCRIPTION
On Linux and Windows systems, links can be opened in new tabs by holding <kbd>Ctrl</kbd> and then left clicking.

This PR allows this default browser behavior for variant links in the sidebar tree navigation.