### PR TITLE
fix(cli): Log format for dev server URL

### DIFF
--- a/lib/i18n/en.js
+++ b/lib/i18n/en.js
@@ -76,7 +76,7 @@ export default {
 				"No schema file found or the schema file could not be parsed as valid JSON.",
 		},
 	},
-	serverStarted: "Running miyagi server at http://localhost:{{port}}!",
+	serverStarted: "Running miyagi server at http://localhost:{{port}}",
 	serverStarting: "Starting miyagi server in {{node_env}} mode…",
 	settingEngineFailed:
 		"Setting the template engine failed. Are you sure the engine defined in your config file is correct?",


### PR DESCRIPTION
The ! character at the end of the dev server URL can trip up terminal regexes which include it as part of the clickable URL.

This removes the ! character so all terminals can make the URL properly clickable.