### PR TITLE
Potential fix for code scanning alert no. 9: Prototype-polluting assignment

### DIFF
--- a/frontend/assets/js/_prism.js
+++ b/frontend/assets/js/_prism.js
@@ -201,7 +201,7 @@ var _self =
 					else o(M.util.encode(l.code));
 				},
 				highlight: function (e, n, t) {
-					var r = { code: e, grammar: n, language: t };
+					var r = { code: e, grammar: new Map(Object.entries(n)), language: t };
 					return (
 						M.hooks.run("before-tokenize", r),
 						(r.tokens = M.tokenize(r.code, r.grammar)),
@@ -210,14 +210,14 @@ var _self =
 					);
 				},
 				tokenize: function (e, n) {
-					var t = n.rest;
+					var t = n.get('rest');
 					if (t) {
 						for (var r in t) {
 							if (Object.prototype.hasOwnProperty.call(t, r) && r !== '__proto__' && r !== 'constructor' && r !== 'prototype') {
-								n[r] = t[r];
+								n.set(r, t[r]);
 							}
 						}
-						delete n.rest;
+						n.delete('rest');
 					}
 					var a = new i();
 					return (


### PR DESCRIPTION
Potential fix for [https://github.com/miyagi-dev/miyagi/security/code-scanning/9](https://github.com/miyagi-dev/miyagi/security/code-scanning/9)

To fix the problem, we will replace the object `n` with a `Map` object. This will ensure that even if an attacker tries to use a dangerous key, it won't affect the `Object.prototype`. We will need to update the code to use `Map` methods for setting and getting properties.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
