### PR TITLE
fix: New component CLI arg parsing

### DIFF
--- a/lib/init/args.js
+++ b/lib/init/args.js
@@ -22,17 +22,17 @@ export default yargs(hideBin(process.argv))
 	})
 	.command(
 		"new",
-		"Creates a new component folder (including template, mock, documentation, css and js files)",
+		"Creates a new component folder (including template, CSS, JS, documentation, mocks, and schema files)",
 		{
 			skip: {
 				description:
-					"files that will not be created\n(comma separated list of css, docs, js, mocks, tpl)",
-				type: "string",
+					"files that will not be created\n(space separated list of tpl, css, js, docs, mocks, schema)",
+				type: "array",
 			},
 			only: {
 				description:
-					"tells miyagi to only created the passes file types\n(comma separated list of tpl, docs, data, css, js)",
-				type: "string",
+					"tells miyagi to only created the passes file types\n(space separated list of tpl, css, js, docs, mocks, schema)",
+				type: "array",
 			},
 		},
 	)


### PR DESCRIPTION
Yargs needs the explicit `array` type so it parses array arguments correctly. See for more information:

- https://yargs.js.org/docs/#api-reference-arraykey
- https://yargs.js.org/docs/#api-reference-optionskey-opt

I also updated the command descriptions to match the v4 documentation.