### PR TITLE
fix(cli): Clean exit for mock and component generator

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -147,11 +147,15 @@ export default async function Miyagi(cmd, { isBuild: isApiBuild } = {}) {
 		}
 
 		if (isMockGenerator) {
-			return runMockGenerator(global.config, args);
+			await runMockGenerator(global.config, args);
+			// Force-exit in case imported user config has active resources preventing Node.js from exiting.
+			process.exit();
 		}
 
 		if (isComponentGenerator) {
-			return createComponentViaCli(args);
+			await createComponentViaCli(args);
+			// Force-exit in case imported user config has active resources preventing Node.js from exiting.
+			process.exit();
 		}
 
 		return initRendering(global.config);


### PR DESCRIPTION
If the user config contains code that doesn’t stop, for example a file watcher, the CLI hangs because Node.js can’t exit.

This pull request enforces a clean exit after miyagi finished generating mocks or components.